### PR TITLE
GovReport needs longer generation output limits, and minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are multiple model cards available on HuggingfaceHub including
 - [Bart-Base SLED](https://huggingface.co/tau/bart-base-sled) (model name `tau/bart-base-sled`)
 - [Bart-Large SLED](https://huggingface.co/tau/bart-large-sled) (model name `tau/bart-base-sled`)
 - [T5(v1.1)-base SLED](https://huggingface.co/tau/t5-v1_1-base-sled) (model name `tau/t5-v1_1-base-sled`)
-- [T5(v1.1)-large SLED](https://huggingface.co/tau/t5-v1_1-large-sled) (model name `tau/t5-v1_1-largeß-sled`)
+- [T5(v1.1)-large SLED](https://huggingface.co/tau/t5-v1_1-large-sled) (model name `tau/t5-v1_1-large-sled`)
 
 If you wish to use a custom model that is available as a model card (public or private) on the hub, or use 
 different parameters for SLED, you can create a json config file like the below, and change the underlying_config to your custom model card.

--- a/examples/seq2seq/README.md
+++ b/examples/seq2seq/README.md
@@ -24,4 +24,4 @@ configs/training/base_training_args.json \
 --learning_rate 2e-5
 ```
 
-Examples jsons files are [here](https://github.com/Mivg/sled_dev/tree/main/examples/seq2seq/configs).
+Examples jsons files are [here](https://github.com/Mivg/SLED/tree/main/examples/seq2seq/configs).

--- a/examples/seq2seq/configs/data/gov_report.json
+++ b/examples/seq2seq/configs/data/gov_report.json
@@ -2,6 +2,7 @@
   "dataset_name": "tau/sled",
   "dataset_config_name": "gov_report",
   "max_source_length": 16384,
+  "generation_max_length": 1024,
   "max_prefix_length": 0,
   "num_train_epochs": 10,
   "metric_names": ["rouge"],


### PR DESCRIPTION
* GovReport has longer outputs than other Scrolls datasets, so we need to set a default of `"generation_max_length": 1024` (otherwise, it will use `128` which is much lower than the average output length)
* Minor typo and a broken link in READMEs